### PR TITLE
Set activate on single click to false for the language selection listbox

### DIFF
--- a/fonts_compare.py
+++ b/fonts_compare.py
@@ -952,7 +952,7 @@ class AppWindow(Gtk.ApplicationWindow): # type: ignore
         listbox = Gtk.ListBox()
         listbox.set_vexpand(True)
         listbox.set_selection_mode(Gtk.SelectionMode.SINGLE)
-        listbox.set_activate_on_single_click(True)
+        listbox.set_activate_on_single_click(False)
         rows = []
         filter_words = remove_accents(filter_text.lower()).split()
         currently_selected_visible = False
@@ -993,8 +993,6 @@ class AppWindow(Gtk.ApplicationWindow): # type: ignore
                 'row-selected',
                 self._on_language_menu_popover_listbox_row_selected)
         self._language_menu_popover_scroll.set_child(listbox)
-
-
 
     def _on_language_menu_popover_listbox_row_selected(
             self, _listbox: Gtk.ListBox, listbox_row: Gtk.ListBoxRow) -> None:


### PR DESCRIPTION
Resolves: https://github.com/sudipshil9862/fonts-compare/issues/43

We use listbox.set_selection_mode(Gtk.SelectionMode.SINGLE) that is enough to select a language by a single click on a row. Using listbox.set_activate_on_single_click(True) in addition to that causes the problem that when an already selected row is clicked, the signal “row-selected” is not emitted but the signal “row-activated” and we did not connect anything to that signal. We also do not need to connect a function to that signal because when we use

listbox.set_activate_on_single_click(False)

then a single click on the already selected row with the current language will emit the signal “row-selected” and then everything works as expected, the currently selected language is selected again, which works just fine.